### PR TITLE
table now queries the associate db directly

### DIFF
--- a/app/controllers/tables_controller.rb
+++ b/app/controllers/tables_controller.rb
@@ -1,10 +1,9 @@
 class TablesController < ApplicationController
   before_action :set_table, only: [:show, :update, :destroy]
+  before_action :get_tables, only: [:index]
 
   # GET /tables
   def index
-    @tables = current_user.tables.all
-
     render json: @tables
   end
 
@@ -39,6 +38,11 @@ class TablesController < ApplicationController
   end
 
   private
+
+    # Get tables associated with a particular db
+    def get_tables
+      @tables = Table.for_database_id(params[:db_id])
+    end
     # Use callbacks to share common setup or constraints between actions.
     def set_table
       @table = current_user.tables.find(params[:id])

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -9,6 +9,29 @@ class Table < ApplicationRecord
   after_commit :trigger_table_creation, on: :create
   before_destroy :trigger_table_destruction
 
+  def self.for_database_id(database_id)
+    # Get the database associated with the database id
+    db = Database.find(database_id)
+    # Get the project asscoiated with this database
+    project = Project.find(db.project_id)
+    # Get the users of the associated database
+    associated_database_user = ::Natural::DatabaseUser.new(project.db_username,project.db_password)
+    associated_database = ::Natural::Database.new(db.database_identifier)
+    connection = ::Natural::Connection.new
+    connection.db_user = associated_database_user
+    connection.database = associated_database
+     # Connect to the associated db
+    connection.establish_connection
+    associated_database.connection = connection
+     # Get all the tables  in the associated db for the associated user
+    tables = associated_database.tables(project.db_username)
+     # Close connection after query
+    connection.close
+     # Return the result
+    tables.to_a.entries
+  end
+
+
  private
 
   def trigger_table_creation

--- a/lib/database_manager/lib/database.rb
+++ b/lib/database_manager/lib/database.rb
@@ -29,6 +29,14 @@ module Natural
       table(table_identifier).exists?
     end
 
+    def tables(associated_db_user)
+      connection.exec(
+        """
+        SELECT tablename FROM pg_catalog.pg_tables WHERE tableowner = \'#{associated_db_user}\';
+        """
+      )
+    end
+
     def create
       connection.exec(
         """


### PR DESCRIPTION
When getting the tables ,it will now directly query the associate db and return the table names, instead of reading them of the `tables` table in the main `natural` database.

also when getting all the tables, please query with the  database id i.e. `/tables?db_id=1`